### PR TITLE
Port to GNOME 46

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,10 +1,9 @@
 {
 	"name": "Default Workspace",
 	"description": "Switches to the specified workspace on login.\nUseful for fixed number of workspace setups where the first workspace isn't the main one.",
-	"shell-version": ["45"],
+	"shell-version": ["45", "46"],
 	"url": "https://github.com/MateusRodCosta/gnome-shell-extension-default-workspace",
 	"uuid": "default-workspace@mateusrodcosta.com",
 	"settings-schema": "org.gnome.shell.extensions.default-workspace",
-	"version": 6
-
+	"version": 7
 }


### PR DESCRIPTION
Now with the release of Gnome 46, the extension has stopped working. I then made the necessary changes so that the extension works in the new version of Gnome.